### PR TITLE
Added sequential command group for coral intake

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -219,6 +219,10 @@ public final class Constants {
       // Height of coral bucket hinge for coral intake
       public static final double kElevatorIntakeHeight = 25;
       // guess??? maybe? not accurate check when elevator attatched
+      // Elevator goes above intake before algae arm goes up,
+      // then elevator goes to intake height,
+      // this is height difference (inches)
+      public static final double kElevatorAboveIntakeHeightDifference = 8;
       // Offset of elevator for coral to line up with reef branch (inches)
       // Center of coral lines up with top of branch
       // Signed, negative moves down, positive moves up

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,14 +11,11 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.auto.*;
-import frc.robot.commands.AlgaeSpinnerForwardCommand;
-import frc.robot.commands.AlgaeSpinnerReverseCommand;
-import frc.robot.commands.AlgaeSpinnerStopCommand;
-import frc.robot.commands.CoralIntakeForwardCommand;
-import frc.robot.commands.CoralIntakeReverseCommand;
-import frc.robot.commands.CoralIntakeStopCommand;
 // import frc.robot.auto.plans.*;
 import frc.robot.commands.TeleopCmd;
+import frc.robot.commands.algaeArm.*;
+import frc.robot.commands.coralIntake.*;
+import frc.robot.commands.elevator.*;
 import frc.robot.subsystems.AlgaeArmSubsystem;
 import frc.robot.subsystems.CoralIntakeSubsystem;
 import frc.robot.subsystems.DrivetrainSubsystem;
@@ -89,7 +86,6 @@ public class RobotContainer {
             cutil.getTriggerButton(Controllers.xbox_lt, 0.2, DriveConstants.joysticks.OPERATOR)
                 ? new AlgaeSpinnerReverseCommand(algaeArm)
                 : new AlgaeSpinnerStopCommand(algaeArm));
-
     cutil
         .triggerSupplier(Controllers.xbox_rt, 0.2, DriveConstants.joysticks.OPERATOR)
         .onTrue(new AlgaeSpinnerReverseCommand(algaeArm))
@@ -111,6 +107,21 @@ public class RobotContainer {
         .supplier(Controllers.xbox_options, DriveConstants.joysticks.OPERATOR)
         .onTrue(new InstantCommand(() -> elevator.toBase()));
 
+    // Intake sequential command binding
+    cutil
+        .supplier(Controllers.xbox_a, DriveConstants.joysticks.OPERATOR)
+        .onTrue(
+            new SequentialCommandGroup(
+                new ElevatorToAboveIntakeCommand(elevator),
+                new AlgaeArmToUpCommand(algaeArm),
+                new ElevatorToIntakeCommand(elevator),
+                new CoralIntakeForwardCommand(coralIntake)))
+        .onFalse(
+            new SequentialCommandGroup(
+                new CoralIntakeStopCommand(coralIntake),
+                new ElevatorToAboveIntakeCommand(elevator),
+                new AlgaeArmToDownCommand(algaeArm)));
+
     // Coral Intake Bindings
     cutil
         .supplier(Controllers.xbox_lb, DriveConstants.joysticks.OPERATOR)
@@ -119,7 +130,6 @@ public class RobotContainer {
             cutil.getTriggerButton(Controllers.xbox_lt, 0.2, DriveConstants.joysticks.OPERATOR)
                 ? new CoralIntakeReverseCommand(coralIntake)
                 : new CoralIntakeStopCommand(coralIntake));
-
     cutil
         .triggerSupplier(Controllers.xbox_lt, 0.2, DriveConstants.joysticks.OPERATOR)
         .onTrue(new CoralIntakeReverseCommand(coralIntake))

--- a/src/main/java/frc/robot/commands/algaeArm/AlgaeArmToDownCommand.java
+++ b/src/main/java/frc/robot/commands/algaeArm/AlgaeArmToDownCommand.java
@@ -2,23 +2,23 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands;
+package frc.robot.commands.algaeArm;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.CoralIntakeSubsystem;
+import frc.robot.subsystems.AlgaeArmSubsystem;
 
 /** An example command that uses an example subsystem. */
-public class CoralIntakeForwardCommand extends Command {
+public class AlgaeArmToDownCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final CoralIntakeSubsystem coralIntake_subsystem;
+  private final AlgaeArmSubsystem algaeArm_subsystem;
 
   /**
    * Creates a new ExampleCommand.
    *
    * @param subsystem The subsystem used by this command.
    */
-  public CoralIntakeForwardCommand(CoralIntakeSubsystem subsystem) {
-    coralIntake_subsystem = subsystem;
+  public AlgaeArmToDownCommand(AlgaeArmSubsystem subsystem) {
+    algaeArm_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }
@@ -30,7 +30,7 @@ public class CoralIntakeForwardCommand extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    coralIntake_subsystem.coralIntakeForwardCmd();
+    algaeArm_subsystem.toDown();
   }
 
   // Called once the command ends or is interrupted.
@@ -40,6 +40,7 @@ public class CoralIntakeForwardCommand extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return false;
+    return (algaeArm_subsystem.getSetPoint() - 0.5 <= algaeArm_subsystem.getRelativeRotation()
+        && algaeArm_subsystem.getRelativeRotation() <= algaeArm_subsystem.getSetPoint() + 0.5);
   }
 }

--- a/src/main/java/frc/robot/commands/algaeArm/AlgaeArmToUpCommand.java
+++ b/src/main/java/frc/robot/commands/algaeArm/AlgaeArmToUpCommand.java
@@ -1,0 +1,46 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.algaeArm;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.AlgaeArmSubsystem;
+
+/** An example command that uses an example subsystem. */
+public class AlgaeArmToUpCommand extends Command {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final AlgaeArmSubsystem algaeArm_subsystem;
+
+  /**
+   * Creates a new ExampleCommand.
+   *
+   * @param subsystem The subsystem used by this command.
+   */
+  public AlgaeArmToUpCommand(AlgaeArmSubsystem subsystem) {
+    algaeArm_subsystem = subsystem;
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(subsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    algaeArm_subsystem.toUp();
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return (algaeArm_subsystem.getSetPoint() - 0.5 <= algaeArm_subsystem.getRelativeRotation()
+        && algaeArm_subsystem.getRelativeRotation() <= algaeArm_subsystem.getSetPoint() + 0.5);
+  }
+}

--- a/src/main/java/frc/robot/commands/algaeArm/AlgaeSpinnerForwardCommand.java
+++ b/src/main/java/frc/robot/commands/algaeArm/AlgaeSpinnerForwardCommand.java
@@ -2,23 +2,23 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands;
+package frc.robot.commands.algaeArm;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.CoralIntakeSubsystem;
+import frc.robot.subsystems.AlgaeArmSubsystem;
 
 /** An example command that uses an example subsystem. */
-public class CoralIntakeStopCommand extends Command {
+public class AlgaeSpinnerForwardCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final CoralIntakeSubsystem coralIntake_subsystem;
+  private final AlgaeArmSubsystem algaeArm_subsystem;
 
   /**
    * Creates a new ExampleCommand.
    *
    * @param subsystem The subsystem used by this command.
    */
-  public CoralIntakeStopCommand(CoralIntakeSubsystem subsystem) {
-    coralIntake_subsystem = subsystem;
+  public AlgaeSpinnerForwardCommand(AlgaeArmSubsystem subsystem) {
+    algaeArm_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }
@@ -30,7 +30,7 @@ public class CoralIntakeStopCommand extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    coralIntake_subsystem.coralIntakeStopCmd();
+    algaeArm_subsystem.algaeSpinnerForwardCmd();
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/algaeArm/AlgaeSpinnerReverseCommand.java
+++ b/src/main/java/frc/robot/commands/algaeArm/AlgaeSpinnerReverseCommand.java
@@ -2,7 +2,7 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands;
+package frc.robot.commands.algaeArm;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.AlgaeArmSubsystem;
@@ -10,7 +10,7 @@ import frc.robot.subsystems.AlgaeArmSubsystem;
 /** An example command that uses an example subsystem. */
 public class AlgaeSpinnerReverseCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final AlgaeArmSubsystem algaeSpinner_subsystem;
+  private final AlgaeArmSubsystem algaeArm_subsystem;
 
   /**
    * Creates a new ExampleCommand.
@@ -18,7 +18,7 @@ public class AlgaeSpinnerReverseCommand extends Command {
    * @param subsystem The subsystem used by this command.
    */
   public AlgaeSpinnerReverseCommand(AlgaeArmSubsystem subsystem) {
-    algaeSpinner_subsystem = subsystem;
+    algaeArm_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }
@@ -30,7 +30,7 @@ public class AlgaeSpinnerReverseCommand extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    algaeSpinner_subsystem.algaeSpinnerReverseCmd();
+    algaeArm_subsystem.algaeSpinnerReverseCmd();
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/algaeArm/AlgaeSpinnerStopCommand.java
+++ b/src/main/java/frc/robot/commands/algaeArm/AlgaeSpinnerStopCommand.java
@@ -1,0 +1,45 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.algaeArm;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.AlgaeArmSubsystem;
+
+/** An example command that uses an example subsystem. */
+public class AlgaeSpinnerStopCommand extends Command {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final AlgaeArmSubsystem algaeArm_subsystem;
+
+  /**
+   * Creates a new ExampleCommand.
+   *
+   * @param subsystem The subsystem used by this command.
+   */
+  public AlgaeSpinnerStopCommand(AlgaeArmSubsystem subsystem) {
+    algaeArm_subsystem = subsystem;
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(subsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    algaeArm_subsystem.algaeSpinnerStopCmd();
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/coralIntake/CoralIntakeForwardCommand.java
+++ b/src/main/java/frc/robot/commands/coralIntake/CoralIntakeForwardCommand.java
@@ -2,23 +2,23 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands;
+package frc.robot.commands.coralIntake;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.AlgaeArmSubsystem;
+import frc.robot.subsystems.CoralIntakeSubsystem;
 
 /** An example command that uses an example subsystem. */
-public class AlgaeSpinnerStopCommand extends Command {
+public class CoralIntakeForwardCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final AlgaeArmSubsystem algaeSpinner_subsystem;
+  private final CoralIntakeSubsystem coralIntake_subsystem;
 
   /**
    * Creates a new ExampleCommand.
    *
    * @param subsystem The subsystem used by this command.
    */
-  public AlgaeSpinnerStopCommand(AlgaeArmSubsystem subsystem) {
-    algaeSpinner_subsystem = subsystem;
+  public CoralIntakeForwardCommand(CoralIntakeSubsystem subsystem) {
+    coralIntake_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }
@@ -30,7 +30,7 @@ public class AlgaeSpinnerStopCommand extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    algaeSpinner_subsystem.algaeSpinnerStopCmd();
+    coralIntake_subsystem.coralIntakeForwardCmd();
   }
 
   // Called once the command ends or is interrupted.

--- a/src/main/java/frc/robot/commands/coralIntake/CoralIntakeReverseCommand.java
+++ b/src/main/java/frc/robot/commands/coralIntake/CoralIntakeReverseCommand.java
@@ -1,0 +1,45 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.coralIntake;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.CoralIntakeSubsystem;
+
+/** An example command that uses an example subsystem. */
+public class CoralIntakeReverseCommand extends Command {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final CoralIntakeSubsystem coralIntake_subsystem;
+
+  /**
+   * Creates a new ExampleCommand.
+   *
+   * @param subsystem The subsystem used by this command.
+   */
+  public CoralIntakeReverseCommand(CoralIntakeSubsystem subsystem) {
+    coralIntake_subsystem = subsystem;
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(subsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    coralIntake_subsystem.coralIntakeForwardCmd();
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+}

--- a/src/main/java/frc/robot/commands/coralIntake/CoralIntakeStopCommand.java
+++ b/src/main/java/frc/robot/commands/coralIntake/CoralIntakeStopCommand.java
@@ -1,0 +1,45 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.coralIntake;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.CoralIntakeSubsystem;
+
+/** An example command that uses an example subsystem. */
+public class CoralIntakeStopCommand extends Command {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
+  private final CoralIntakeSubsystem coralIntake_subsystem;
+
+  /**
+   * Creates a new ExampleCommand.
+   *
+   * @param subsystem The subsystem used by this command.
+   */
+  public CoralIntakeStopCommand(CoralIntakeSubsystem subsystem) {
+    coralIntake_subsystem = subsystem;
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(subsystem);
+  }
+
+  // Called when the command is initially scheduled.
+  @Override
+  public void initialize() {}
+
+  // Called every time the scheduler runs while the command is scheduled.
+  @Override
+  public void execute() {
+    coralIntake_subsystem.coralIntakeStopCmd();
+  }
+
+  // Called once the command ends or is interrupted.
+  @Override
+  public void end(boolean interrupted) {}
+
+  // Returns true when the command should end.
+  @Override
+  public boolean isFinished() {
+    return true;
+  }
+}

--- a/src/main/java/frc/robot/commands/elevator/ElevatorToAboveIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/elevator/ElevatorToAboveIntakeCommand.java
@@ -2,23 +2,23 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands;
+package frc.robot.commands.elevator;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.AlgaeArmSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
 
 /** An example command that uses an example subsystem. */
-public class AlgaeSpinnerForwardCommand extends Command {
+public class ElevatorToAboveIntakeCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final AlgaeArmSubsystem algaeSpinner_subsystem;
+  private final ElevatorSubsystem elevator_subsystem;
 
   /**
    * Creates a new ExampleCommand.
    *
    * @param subsystem The subsystem used by this command.
    */
-  public AlgaeSpinnerForwardCommand(AlgaeArmSubsystem subsystem) {
-    algaeSpinner_subsystem = subsystem;
+  public ElevatorToAboveIntakeCommand(ElevatorSubsystem subsystem) {
+    elevator_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }
@@ -30,7 +30,7 @@ public class AlgaeSpinnerForwardCommand extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    algaeSpinner_subsystem.algaeSpinnerForwardCmd();
+    elevator_subsystem.toAboveIntake();
   }
 
   // Called once the command ends or is interrupted.
@@ -40,6 +40,7 @@ public class AlgaeSpinnerForwardCommand extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return false;
+    return (elevator_subsystem.getSetPoint() - 0.5 <= elevator_subsystem.getRelativeHeight()
+        && elevator_subsystem.getRelativeHeight() <= elevator_subsystem.getSetPoint() + 0.5);
   }
 }

--- a/src/main/java/frc/robot/commands/elevator/ElevatorToIntakeCommand.java
+++ b/src/main/java/frc/robot/commands/elevator/ElevatorToIntakeCommand.java
@@ -2,23 +2,23 @@
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
 
-package frc.robot.commands;
+package frc.robot.commands.elevator;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import frc.robot.subsystems.CoralIntakeSubsystem;
+import frc.robot.subsystems.ElevatorSubsystem;
 
 /** An example command that uses an example subsystem. */
-public class CoralIntakeReverseCommand extends Command {
+public class ElevatorToIntakeCommand extends Command {
   @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
-  private final CoralIntakeSubsystem coralIntake_subsystem;
+  private final ElevatorSubsystem elevator_subsystem;
 
   /**
    * Creates a new ExampleCommand.
    *
    * @param subsystem The subsystem used by this command.
    */
-  public CoralIntakeReverseCommand(CoralIntakeSubsystem subsystem) {
-    coralIntake_subsystem = subsystem;
+  public ElevatorToIntakeCommand(ElevatorSubsystem subsystem) {
+    elevator_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
   }
@@ -30,7 +30,7 @@ public class CoralIntakeReverseCommand extends Command {
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    coralIntake_subsystem.coralIntakeForwardCmd();
+    elevator_subsystem.toIntake();
   }
 
   // Called once the command ends or is interrupted.
@@ -40,6 +40,7 @@ public class CoralIntakeReverseCommand extends Command {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return false;
+    return (elevator_subsystem.getSetPoint() - 0.5 <= elevator_subsystem.getRelativeHeight()
+        && elevator_subsystem.getRelativeHeight() <= elevator_subsystem.getSetPoint() + 0.5);
   }
 }

--- a/src/main/java/frc/robot/subsystems/AlgaeArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/AlgaeArmSubsystem.java
@@ -27,6 +27,8 @@ public class AlgaeArmSubsystem extends SubsystemBase {
   private final PIDController algaeArmPID =
       new PIDController(PIDConstants.kAlgaeArmP, PIDConstants.kAlgaeArmI, PIDConstants.kAlgaeArmD);
 
+  private double algaeArmPIDSetPoint;
+
   public AlgaeArmSubsystem() {
     m_AlgaeArmEncoder = m_AlgaeArmSparkMax.getEncoder();
   }
@@ -44,19 +46,27 @@ public class AlgaeArmSubsystem extends SubsystemBase {
   }
 
   public void toDown() {
-    algaeArmPID.setSetpoint(AlgaeArmConstants.kAlgaeArmStopRotations[0]);
+    algaeArmPIDSetPoint = (AlgaeArmConstants.kAlgaeArmStopRotations[0]);
   }
 
   public void toFlat() {
-    algaeArmPID.setSetpoint(AlgaeArmConstants.kAlgaeArmStopRotations[1]);
+    algaeArmPIDSetPoint = (AlgaeArmConstants.kAlgaeArmStopRotations[1]);
   }
 
   public void toRemoveAlgae() {
-    algaeArmPID.setSetpoint(AlgaeArmConstants.kAlgaeArmStopRotations[2]);
+    algaeArmPIDSetPoint = (AlgaeArmConstants.kAlgaeArmStopRotations[2]);
   }
 
   public void toUp() {
-    algaeArmPID.setSetpoint(AlgaeArmConstants.kAlgaeArmStopRotations[3]);
+    algaeArmPIDSetPoint = (AlgaeArmConstants.kAlgaeArmStopRotations[3]);
+  }
+
+  public double getRelativeRotation() {
+    return (m_AlgaeArmEncoder.getPosition() * AlgaeArmConstants.kAlgaeArmGearRatio);
+  }
+
+  public double getSetPoint() {
+    return algaeArmPIDSetPoint;
   }
 
   @Override
@@ -66,5 +76,6 @@ public class AlgaeArmSubsystem extends SubsystemBase {
         algaeArmPID.calculate(
             m_AlgaeArmEncoder.getPosition() * AlgaeArmConstants.kAlgaeArmGearRatio);
     m_AlgaeArmSparkMax.set(elevatorSpeed);
+    algaeArmPID.setSetpoint(algaeArmPIDSetPoint);
   }
 }

--- a/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ElevatorSubsystem.java
@@ -33,6 +33,8 @@ public class ElevatorSubsystem extends SubsystemBase {
   private final PIDController elevatorPID =
       new PIDController(PIDConstants.kElevatorP, PIDConstants.kElevatorI, PIDConstants.kElevatorD);
 
+  private double elevatorPIDSetPoint;
+
   public ElevatorSubsystem() {
 
     m_elevator2Config = new SparkMaxConfig();
@@ -46,35 +48,49 @@ public class ElevatorSubsystem extends SubsystemBase {
   }
 
   public void toBase() {
-    elevatorPID.setSetpoint(ElevatorConstants.kElevatorStopsTested[0]);
+    elevatorPIDSetPoint = (ElevatorConstants.kElevatorStopsTested[0]);
   }
 
   public void toL1() {
-    elevatorPID.setSetpoint(ElevatorConstants.kElevatorStopsTested[1]);
+    elevatorPIDSetPoint = (ElevatorConstants.kElevatorStopsTested[1]);
   }
 
   public void toL2() {
-    elevatorPID.setSetpoint(ElevatorConstants.kElevatorStopsTested[2]);
+    elevatorPIDSetPoint = (ElevatorConstants.kElevatorStopsTested[2]);
   }
 
   public void toL3() {
-    elevatorPID.setSetpoint(ElevatorConstants.kElevatorStopsTested[3]);
+    elevatorPIDSetPoint = (ElevatorConstants.kElevatorStopsTested[3]);
   }
 
   public void toL4() {
-    elevatorPID.setSetpoint(ElevatorConstants.kElevatorStopsTested[4]);
+    elevatorPIDSetPoint = (ElevatorConstants.kElevatorStopsTested[4]);
   }
 
   public void toIntake() {
-    elevatorPID.setSetpoint(ElevatorConstants.kElevatorStopsTested[5]);
+    elevatorPIDSetPoint = (ElevatorConstants.kElevatorStopsTested[5]);
   }
 
-  // Logs print encoder and corresponding elevator height values
+  public void toAboveIntake() {
+    elevatorPIDSetPoint =
+        (ElevatorConstants.kElevatorStopsTested[5]
+            + ElevatorConstants.kElevatorAboveIntakeHeightDifference);
+  }
+
   public double getHeight() {
     return ((m_elevator1Encoder.getPosition() * ElevatorConstants.kElevatorHeightToRot)
         + ElevatorConstants.kElevatorLowestHeight);
   }
 
+  public double getRelativeHeight() {
+    return (m_elevator1Encoder.getPosition() * ElevatorConstants.kElevatorHeightToRot);
+  }
+
+  public double getSetPoint() {
+    return elevatorPIDSetPoint;
+  }
+
+  // Logs print encoder and corresponding elevator height values
   // Possible print method for heightGet:
   /*
   System.out.println("Encoder: " + m_elevator1Encoder.getPosition() + " rotations");
@@ -95,6 +111,7 @@ public class ElevatorSubsystem extends SubsystemBase {
         elevatorPID.calculate(
             m_elevator1Encoder.getPosition() * ElevatorConstants.kElevatorHeightToRot);
     m_elevator1SparkMax.set(elevatorSpeed);
+    elevatorPID.setSetpoint(elevatorPIDSetPoint);
 
     SmartDashboard.putNumber("Elevator Height", getHeight());
   }


### PR DESCRIPTION
Sequential command group for coral intake was added. Methods used for PID motor movement was changed slightly to be more compatible with the sequential commands. With the addition of more commands, as needed for the sequential command, folders were made for different groups of commands, which github sees as adding and deleting the same thing from different locations.