### PR TITLE
Add build info logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ compile_commands.json
 
 # Eclipse generated file for annotation processors
 .factorypath
+
+# Generated Constants with Git/build info
+src/main/java/frc/robot/BuildConstants.java

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2025.2.1"
     id 'com.diffplug.spotless' version '7.0.2'
+    id "com.peterabeles.gversion" version "1.10.3"
 }
 
 java {
@@ -113,7 +114,7 @@ spotless {
     java {
         target fileTree('.') {
             include '**/*.java'
-            exclude '**/build/**', '**/build-*/**'
+            exclude '**/build/**', '**/build-*/**', '**/BuildConstants.java'
         }
         toggleOffOn()
         googleJavaFormat()
@@ -149,4 +150,14 @@ spotless {
         leadingTabsToSpaces(2)
         endWithNewline()
     }
+}
+
+project.compileJava.dependsOn(createVersionFile)
+gversion {
+  srcDir       = "src/main/java/"
+  classPackage = "frc.robot"
+  className    = "BuildConstants"
+  dateFormat   = "yyyy-MM-dd HH:mm:ss z"
+  timeZone     = "America/New_York" // Use preferred time zone
+  indent       = "  "
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -68,11 +68,19 @@ public class RobotContainer {
       new MiddleOneCoralPlan(drivetrain, elevator, coralIntake);
   private final LeftOneCoralPlan leftOneCoralPlan =
       new LeftOneCoralPlan(drivetrain, elevator, coralIntake);
+  private static final String[] GIT_FLAG = {"clean", "dirty"};
 
   public RobotContainer() {
 
     DataLogManager.start();
     URCL.start();
+
+    // log build information
+    DataLogManager.log("Git branch: " + BuildConstants.GIT_BRANCH);
+    DataLogManager.log("Git date: " + BuildConstants.GIT_DATE);
+    DataLogManager.log("Git hash: " + BuildConstants.GIT_SHA);
+    DataLogManager.log("Git branch status: " + GIT_FLAG[BuildConstants.DIRTY]);
+    DataLogManager.log("Build date: " + BuildConstants.BUILD_DATE);
 
     // Default Commands to be run all the time, only one per subsystem
     drivetrain.setDefaultCommand(teleopCmd);


### PR DESCRIPTION
This adds logging on robot startup that prints git branch/commit/status/date/etc. BuildConstants.java is auto-generated with every build, so it's in .gitignore and excluded from Spotless checks.